### PR TITLE
Fixes for making xv6 for AArch64 re-work.

### DIFF
--- a/xv6-armv8/arm.h
+++ b/xv6-armv8/arm.h
@@ -21,9 +21,6 @@
 // and switches to a new process (including user-space banked registers)
 #ifndef __ASSEMBLER__
 struct trapframe {
-    uint64    sp;     // user mode sp
-    uint64    pc;     // user mode pc (elr)
-    uint64    spsr;
     uint64    r0;
     uint64    r1;
     uint64    r2;
@@ -55,6 +52,9 @@ struct trapframe {
     uint64    r28;
     uint64    r29;
     uint64    r30;	// user mode lr
+    uint64    sp;     // user mode sp
+    uint64    pc;     // user mode pc (elr)
+    uint64    spsr;
 };
 #endif
 

--- a/xv6-armv8/trap_asm.S
+++ b/xv6-armv8/trap_asm.S
@@ -20,8 +20,8 @@
 	stp	x0, x1, [sp, #-16]!
 	add x21, sp, #0x110
 
-	mrs	x22, elr_el3             /* ELR */
-	mrs	x23, spsr_el3            /* SPSR */
+	mrs	x22, elr_el1             /* ELR */
+	mrs	x23, spsr_el1            /* SPSR */
 
 	stp	x30, x21, [sp, #0xf0]    /* LR, SP */
 	stp	x22, x23, [sp, #0x100]   /* ELR, SPSR */
@@ -31,8 +31,8 @@
 	ldp	x22, x23, [sp, #0x100]   /* ELR, SPSR */
 	ldp	x30, x28, [sp, #0xf0]    /* LR, SP */
 
-	msr	elr_el3, x22             /* ELR */
-	msr	spsr_el3, x23
+	msr	elr_el1, x22             /* ELR */
+	msr	spsr_el1, x23
 	
 	mov x29, sp
 	mov sp, x28
@@ -75,8 +75,8 @@
 	stp	x0, x1, [sp, #-16]!
 
 	mrs x21, sp_el0
-	mrs	x22, elr_el3             /* ELR */
-	mrs	x23, spsr_el3            /* SPSR */
+	mrs	x22, elr_el1             /* ELR */
+	mrs	x23, spsr_el1            /* SPSR */
 
 	stp	x30, x21, [sp, #0xf0]    /* LR, SP */
 	stp	x22, x23, [sp, #0x100]   /* ELR, SPSR */
@@ -86,11 +86,12 @@
 	ldp	x22, x23, [sp, #0x100]   /* ELR, SPSR */
 	ldp	x30, x28, [sp, #0xf0]    /* LR, SP */
 
-	msr	elr_el3, x22             /* ELR */
-	msr	spsr_el3, x23
+	msr	elr_el1, x22             /* ELR */
+	msr	spsr_el1, x23
 	msr sp_el0, x28
 
 	mov x29, sp
+	add sp, sp, #0x110
 
 	ldp	x0, x1, [x29], #16
 	ldp	x2, x3, [x29], #16


### PR DESCRIPTION
Hi, sudharson14,

I fixed some codes to make  xv6 for AArch64 re-work.

 (1) Fix the definition of struct trapframe to adapt to the current trap frame in trap_asm.S.
 (2) Because EL3 should be used by  security monitors not by OS kernels,
     use elr_el1, spsr_el1 instead of elr_el3, spsr_el3 .
 (3) Restore a kernel stack pointer ( sp ) to the value where pointed to
     when enter the kernel ( this should be the bottom of process's kernel stack. )
     when the  kernel return to EL0.

I should have written the codes to move into EL1 from EL2/EL3 before I send this PR.
But I cannot write and test such codes because I do not have a machine which boots kernel from EL3.

Would you please review this PR and merge this.

Thanks,
Regards,