### PR TITLE
Adding codes to enter EL1 from EL3 and EL2

### DIFF
--- a/xv6-armv8/entry.S
+++ b/xv6-armv8/entry.S
@@ -6,7 +6,42 @@
 .global _start
 
 _start:
+	mrs   x0, CurrentEL
+	and   x0, x0, #0x0C  //  Am I in EL3?
+	cmp   x0, #0xc
+	b.eq  drop_el2
+	cmp   x0, #0x8       //  Am I in EL2?
+	b.eq  drop_el1
+	b     start_el1
+drop_el2:
+	// Drop into EL2 from EL3
+	// SCR_EL3_NS(0x1) | SCR_EL3_RES(0x3<<4) | SCR_EL3_SMA(1<<7) | SCR_EL3_RW(0x1<<10)
+	mov   x0, #( (0x1) | ( 0x3 << 4 ) | ( 0x1 << 7 ) | ( 0x1 << 10 ) )
+	msr   scr_el3, x0
+	adr   x0, start_el2
+	msr   elr_el3, x0
+	// SPSR_FROM_AARCH64(0) | SPSR_MODE_EL2(0x8) | SPSR_SP_SEL_N(0x1)
+	mov   x0, #( 0x8 | 0x1 )
+	msr   spsr_el3, x0
+	eret
+start_el2:
+drop_el1:
+	// Drop into EL1 from EL2
+	// HCR_EL2_RW ( 0x1 << 31 ) 
+	mov   x0, #( 0x1 << 31 )
+	// HCR_EL2_SWIO ( 0x1 << 1 )
+	orr   x0, x0,#( 0x1 << 1 ) 
+	msr   hcr_el2, x0
+	adr   x0, start_el1
+	msr   elr_el2, x0
+	// SPSR_DAIF_D_BIT ( 0x1 << 9 ) | SPSR_DAIF_A_BIT ( 0x1 << 8 ) |
+	// SPSR_DAIF_I_BIT ( 0x1 << 7 ) | SPSR_DAIF_F_BIT ( 0x1 << 6 ) |
+	// SPSR_FROM_AARCH64 (0x0) | SPSR_MODE_EL1(0x4) | SPSR_SP_SEL_N (0x1)
+	mov   x0, #( ( 0x1 << 9 ) | ( 0x1 << 8 ) | ( 0x1 << 7 ) | ( 0x1 << 6 ) | (0x0) | ( 0x4 ) | (0x1) )
+	msr   spsr_el2, x0
+	eret
 
+start_el1:	
 	# initialize stack pointers for svc modes
 	mov     x0, #1     // select SP_EL1
 	msr     spsel, x0


### PR DESCRIPTION
I added codes to enter EL1 from EL3 and EL2 for machines which have EL3 (Secure Monitor) and EL2 ( Hyper Visor ). Some real machines need to this codes to boot xv6 for AArch64. This should have been a part of PR #3 but I did not notice that I can test this code with QEmu-2.9.0 or later.
FYI, we can test this with QEmu-2.9.x's "-M virt,secure=on,virtualization=on" options.
This PR should be applied with PR #3. 

The following gdb-log indicates this PR makes xv6 enter into EL1 from EL3.
```
(gdb) target remote localhost:1234
(gdb) symbol-file kernel.elf
Load new symbol table from "kernel.elf"? (y or n) y
Reading symbols from kernel.elf...done.
(gdb) six
0x0000000040010004 in _start ()
=> 0x40010004 <_start+4>:       mrs     x0, currentel
(gdb)
0x0000000040010008 in _start ()
=> 0x40010008 <_start+8>:       and     x0, x0, #0xc
(gdb)
0x000000004001000c in _start ()
=> 0x4001000c <_start+12>:      cmp     x0, #0xc
(gdb)
0x0000000040010010 in _start ()
=> 0x40010010 <_start+16>:      b.eq    0x40010020 <drop_el2>  // b.none
(gdb)
0x0000000040010020 in drop_el2 ()
=> 0x40010020 <drop_el2>:       mov     x0, #0x4b1                      // #1201
(gdb)
0x0000000040010024 in drop_el2 ()
=> 0x40010024 <drop_el2+4>:     msr     scr_el3, x0
(gdb)
0x0000000040010028 in drop_el2 ()
=> 0x40010028 <drop_el2+8>:     adr     x0, 0x4001003c <start_el2>
(gdb)
0x000000004001002c in drop_el2 ()
=> 0x4001002c <drop_el2+12>:    msr     elr_el3, x0
(gdb)
0x0000000040010030 in drop_el2 ()
=> 0x40010030 <drop_el2+16>:    mov     x0, #0x9                        // #9
(gdb)
0x0000000040010034 in drop_el2 ()
=> 0x40010034 <drop_el2+20>:    msr     spsr_el3, x0
(gdb)
0x0000000040010038 in drop_el2 ()
=> 0x40010038 <drop_el2+24>:    eret
(gdb)
0x000000004001003c in start_el2 ()
=> 0x4001003c <start_el2>:      mov     x0, #0x80000000                 // #2147483648
(gdb)
0x0000000040010040 in start_el2 ()
=> 0x40010040 <start_el2+4>:    orr     x0, x0, #0x2
(gdb)
0x0000000040010044 in start_el2 ()
=> 0x40010044 <start_el2+8>:    msr     hcr_el2, x0
(gdb)
0x0000000040010048 in start_el2 ()
=> 0x40010048 <start_el2+12>:   adr     x0, 0x4001005c <start_el1>
(gdb)
0x000000004001004c in start_el2 ()
=> 0x4001004c <start_el2+16>:   msr     elr_el2, x0
(gdb)
0x0000000040010050 in start_el2 ()
=> 0x40010050 <start_el2+20>:   mov     x0, #0x3c5                      // #965
(gdb)
0x0000000040010054 in start_el2 ()
=> 0x40010054 <start_el2+24>:   msr     spsr_el2, x0
(gdb)
0x0000000040010058 in start_el2 ()
=> 0x40010058 <start_el2+28>:   eret
(gdb)
0x000000004001005c in start_el1 ()
=> 0x4001005c <start_el1>:      mov     x0, #0x1                        // #1
(gdb)
0x0000000040010060 in start_el1 ()
=> 0x40010060 <start_el1+4>:    msr     spsel, x0
(gdb)
0x0000000040010064 in start_el1 ()
=> 0x40010064 <start_el1+8>:    isb <= Original xv6 for AArch64 code started from this line.
```

After that we can start xv6 for AArch64 in EL1 as follows.

```
starting xv6 for ARMv8...
Implementer: ARM Limited
Current EL: EL1
Flushing TLB and Instr Cache
Setting Memory Attribute Indirection Register (MAIR_EL1)
Setting Vector Base Address Register (VBAR_EL1)
Setting Translation Control Register (TCR_EL1)
Setting Translation Table Base Register 1 (TTBR1_EL1)
Setting Translation Table Base Register 0 (TTBR0_EL1)
Setting System Control Register (SCTLR_EL1)
System Configure Completed...

clearing BSS section for the main kernel
Starting Kernel

**************************************************************************
**                                                                      **
**                                                                      **
**                  xv6 on ARMv8-A (64-bit) Architecture                **
**                                                                      **
**                                                                      **
**************************************************************************

init: Starting Shell
$
```

Thanks,
Regards,