### PR TITLE
Fix GIC driver to support Private Peripheral Interrupts (PPI) devices.

### DIFF
--- a/xv6-armv8/device/arm_virt.h
+++ b/xv6-armv8/device/arm_virt.h
@@ -26,9 +26,13 @@
 #define CLK_HZ          1000000     // the clock is 1MHZ
 
 #define VIC_BASE        0x08000000
-#define PIC_TIMER01     13
-#define PIC_TIMER23     11
-#define PIC_UART0       1
-#define PIC_GRAPHIC     19
 
+#define GICD_INTNO_SGIO         (0)
+#define GICD_INTNO_PPIO         (16)
+#define GICD_INTNO_SPIO         (32)
+
+#define PIC_TIMER01     ( GICD_INTNO_SPIO + 13 )
+#define PIC_TIMER23     ( GICD_INTNO_SPIO + 11 )
+#define PIC_UART0       ( GICD_INTNO_SPIO + 1  )
+#define PIC_GRAPHIC     ( GICD_INTNO_SPIO + 19 )
 #endif /* __ARM_VIRT__ */


### PR DESCRIPTION
Hi,

I wrote a patch to make Generic Interrupt Controller (GIC) driver support Private Peripheral Interrupts (PPI) devices. This is needed to support the timer interrupt facility on QEmu for AArch64.

This patch contains:

(1) Introduce macros for the number of interrupt of Software Generated Interrupt (SGI), Private Peripheral Interrupts (PPI), and Shared Peripheral Interrupts (SPI). 
(2) Replace gd_spi_setcfg, gd_spi_enable,  gd_spi_target0 to support both PPI and SPI. To achieve this, I changed the array size of isrs (NUM_INTSRC).

Would you please merge this?

Thanks,
Regards,